### PR TITLE
Added OSDev.org into Operating Systems section

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ It's a great way to learn.
 * [**Rust**: _Writing an OS in Rust_](https://os.phil-opp.com/)
 * [**Rust**: _Add RISC-V Rust Operating System Tutorial_](https://osblog.stephenmarz.com/)
 * [**(any)**: _Linux from scratch_](https://linuxfromscratch.org/lfs)
-
+* [**(any)**: _OSDev.org_](https://wiki.osdev.org/)
 #### Build your own `Physics Engine`
 
 * [**C**: _Video Game Physics Tutorial_](https://www.toptal.com/game/video-game-physics-part-i-an-introduction-to-rigid-body-dynamics)


### PR DESCRIPTION
Related Issue : #1508 
So this PR is related to addition of OSDev.org into the Operating Systems section. This is a really well written and comprehensive platform for OS Development and Working.
I have seen PRs to add this into the operating systems section but they were closed by the authors.

---
_This PR was originally from a fork: **alihassancods/build-your-own-x** (branch: `master`)_